### PR TITLE
Add API to set thread name prefix for threads created by application

### DIFF
--- a/include/beauty/application.hpp
+++ b/include/beauty/application.hpp
@@ -67,6 +67,10 @@ public:
 #endif
     }
 
+    // Sets thread name prefix for threads started by start().
+    // Only has effect before start() is called.
+    void set_thread_name_prefix(const std::string& prefix) { _thread_name_prefix = prefix; }
+
     static application& Instance();
 #if BEAUTY_ENABLE_OPENSSL
     static application& Instance(certificates&& c);
@@ -90,6 +94,8 @@ private:
     enum class State { waiting, started, stopped };
     std::atomic<State> _state{State::waiting}; // Three State allows a good ioc.restart
     std::atomic<int>   _active_threads{0}; // std::barrier in C++20
+
+    std::string _thread_name_prefix = "beauty:wkr_";
 };
 
 // --------------------------------------------------------------------------

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -80,7 +80,7 @@ application::start(int concurrency)
     for(auto& t : _threads) {
         int id = ++_active_threads;
         t = std::thread([this, id] {
-            beauty::thread_set_name("beauty:wkr_" + std::to_string(id));
+            beauty::thread_set_name(_thread_name_prefix + std::to_string(id));
 
             for(;;) {
                 try {


### PR DESCRIPTION
The current behavior leaks implementation details about the underlying technology used by applications instead of letting the application set useful identifying information. This is especially useful in cases there are multiple io_contexts with separate thread pools within the same process.

The default behavior does not change.