### PR TITLE
Use correct location for version.hpp file created by configure_file step

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -111,7 +111,7 @@ elseif(WIN32)
     )
 endif()
 
-configure_file(./version.hpp.in ./beauty/version.hpp)
+configure_file(./version.hpp.in ${CMAKE_BINARY_DIR}/src/beauty/version.hpp)
 
 install(FILES "${CMAKE_BINARY_DIR}/src/beauty/version.hpp"
         DESTINATION include/beauty


### PR DESCRIPTION
The current path does not work in out of source builds.