### PR TITLE
Don't accept more connections if accept fails

### DIFF
--- a/src/acceptor.cpp
+++ b/src/acceptor.cpp
@@ -100,6 +100,8 @@ acceptor::on_accept(boost::system::error_code ec)
     if (ec) {
         fail(ec, "accept");
         _app.stop();
+        // Don't accept more connections if acceptor fails
+        return;
     }
     else {
         // Create the session SLL or not and run it

--- a/tests/application/test_application.cpp
+++ b/tests/application/test_application.cpp
@@ -60,3 +60,25 @@ TEST_CASE("Asynchronous post")
 
     CHECK_EQ(was_called, 1);
 }
+
+// --------------------------------------------------------------------------
+TEST_CASE("External context")
+{
+    boost::asio::io_context ioc;
+    beauty::application app(ioc);
+
+    std::thread([&ioc] { ioc.run(); }).detach();
+
+    app.start();
+
+    int was_called = 0;
+    auto f = [&was_called]() { ++was_called; };
+
+    app.post(f);
+
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    app.stop();
+
+    CHECK_EQ(was_called, 1);
+}

--- a/tests/server/test_server.cpp
+++ b/tests/server/test_server.cpp
@@ -31,6 +31,56 @@ TEST_CASE("Start and stop - multiple threads")
 }
 
 // --------------------------------------------------------------------------
+TEST_CASE("Start and stop - external context")
+{
+    boost::asio::io_context ioc;
+    beauty::application app(ioc);
+    beauty::server server(app);
+
+    std::thread([&ioc] { ioc.run(); }).detach();
+
+    app.start();
+
+    server.listen();
+
+    CHECK_NE(server.endpoint().port(), 0);
+
+    app.stop();
+    ioc.stop();
+}
+
+// --------------------------------------------------------------------------
+TEST_CASE("Start and stop with acceptor failure - external context")
+{
+    boost::asio::io_context ioc;
+    beauty::application app(ioc);
+
+    // two servers that will listen on the same port
+    beauty::server server1(app);
+    beauty::server server2(app);
+
+    std::thread([&ioc] { ioc.run(); }).detach();
+
+    app.start();
+
+    server1.listen();
+
+    CHECK_NE(server1.endpoint().port(), 0);
+
+    server2.listen(server1.endpoint().port());
+
+    // This test was added to test an infinite loop in acceptor. Currently there's
+    // no way easy to check if the loop exists or not except by looking into
+    // stderr of the test. In the future an explicit error callback could be added,
+    // in which case errors could be intercepted and this test could check if error
+    // count is not very large.
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+
+    app.stop();
+    ioc.stop();
+}
+
+// --------------------------------------------------------------------------
 TEST_CASE("Server swagger info")
 {
     beauty::server_info info;


### PR DESCRIPTION
This fixes infinite loop in case application uses an external io_context in which case `_app.stop()` does nothing.