### PR TITLE
Implement support of listening on IPv6

### DIFF
--- a/include/beauty/server.hpp
+++ b/include/beauty/server.hpp
@@ -85,12 +85,20 @@ public:
 
     server& ws(const std::string& path, ws_handler&& handler);
 
+    // Address may be an ip address or a hostname such as localhost, in which case both IPv4 and
+    // IPv6 interfaces will be listened to. Empty string will listen on any address (0.0.0.0 on
+    // IPv4 and [::] on IPv6).
     void listen(int port = 0, const std::string& address = "0.0.0.0");
     void stop();
     void run();
     void wait();
 
-    const beauty::endpoint& endpoint() const { return _endpoint; }
+    const std::vector<beauty::endpoint>& endpoints() { return _endpoints; }
+
+    const beauty::endpoint& endpoint() const {
+        return _endpoints.empty() ? _empty_endpoint : _endpoints.front();
+    }
+
     int port() const { return endpoint().port(); }
 
     const beauty::router& router() const noexcept { return _router; }
@@ -104,9 +112,11 @@ private:
     beauty::application&    _app;
     int                     _concurrency{1};
     beauty::router          _router;
-    std::shared_ptr<beauty::acceptor> _acceptor;
+    // One acceptor for each resolved endpoint
+    std::vector<std::shared_ptr<beauty::acceptor>> _acceptors;
+    std::vector<beauty::endpoint>                  _endpoints;
+    beauty::endpoint        _empty_endpoint;
 
-    beauty::endpoint        _endpoint;
     beauty::server_info     _server_info;
 };
 


### PR DESCRIPTION
Listening on IPv6 in addition to IPv4 requires more complex implementation to handle edge cases:

- Two separate sockets need to be created for both IPv4 and IPv6. because some operating systems can only create IPV6_V6ONLY sockets by default and there's no way to query this on runtime.

- The given addresses are resolved to allow listening on localhost on both IPv4 and IPv6 addresses.

Note that previous implementation may already fail on certain scenarios on machines that only have IPv4 outbound connectivity. For example, IPv6 may be enabled for link-local addresses and clients will pick IPv6 address by default when connecting to localhost and fail as beauty server listens only on IPv4 there.