### PR TITLE
make CMake-only build the default build, make Conan-mode optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSION OFF)
 
 # Some packages...
-if (DEFINED CONAN)
+if (DEFINED CONAN AND CONAN)
     if (NOT EXISTS ${CMAKE_BINARY_DIR}/conan_toolchain.cmake)
         message(FATAL_ERROR "In Conan mode, you must run a 'conan install' command")
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSION OFF)
 
 # Some packages...
-if (NOT DEFINED CONAN OR CONAN)
+if (DEFINED CONAN)
     if (NOT EXISTS ${CMAKE_BINARY_DIR}/conan_toolchain.cmake)
         message(FATAL_ERROR "In Conan mode, you must run a 'conan install' command")
     endif()


### PR DESCRIPTION
In CMake build system properly distinguish between Conan mode and non-Conan build. Conan-mode was always enabled.