### PR TITLE
create shared library on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ if (NOT DEFINED CONAN OR CONAN)
         find_package(OpenSSL CONFIG REQUIRED)
     endif()
 else()
-    find_package(Boost REQUIRED)
+    find_package(Boost REQUIRED COMPONENTS json)
 
     if (BEAUTY_ENABLE_OPENSSL)
         find_package(OpenSSL REQUIRED)

--- a/include/beauty/acceptor.hpp
+++ b/include/beauty/acceptor.hpp
@@ -3,6 +3,7 @@
 #include <beauty/application.hpp>
 #include <beauty/router.hpp>
 #include <beauty/endpoint.hpp>
+#include <beauty/export.hpp>
 
 #include <boost/asio.hpp>
 
@@ -15,7 +16,7 @@ namespace beauty {
 //---------------------------------------------------------------------------
 // Accepts incoming connections and launches the sessions
 //---------------------------------------------------------------------------
-class acceptor : public std::enable_shared_from_this<acceptor>
+class BEAUTY_EXPORT acceptor : public std::enable_shared_from_this<acceptor>
 {
 public:
     acceptor(application& app,

--- a/include/beauty/application.hpp
+++ b/include/beauty/application.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <beauty/certificate.hpp>
+#include <beauty/export.hpp>
 
 #include <boost/asio.hpp>
 
@@ -19,7 +20,7 @@ namespace beauty {
 class timer;
 
 // --------------------------------------------------------------------------
-class application {
+class BEAUTY_EXPORT application {
 public:
     application();
     explicit application(asio::io_context& ioc);
@@ -101,10 +102,10 @@ private:
 // --------------------------------------------------------------------------
 // Singleton direct access
 // --------------------------------------------------------------------------
-void start(int concurrency = 1);
-bool is_started();
-void run();
-void wait();
-void stop();
-void post(std::function<void()>);
+BEAUTY_EXPORT void start(int concurrency = 1);
+BEAUTY_EXPORT bool is_started();
+BEAUTY_EXPORT void run();
+BEAUTY_EXPORT void wait();
+BEAUTY_EXPORT void stop();
+BEAUTY_EXPORT void post(std::function<void()>);
 }

--- a/include/beauty/attributes.hpp
+++ b/include/beauty/attributes.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <beauty/attribute.hpp>
+#include <beauty/export.hpp>
 
 #include <string>
 #include <unordered_map>
@@ -8,7 +9,7 @@
 namespace beauty
 {
 // --------------------------------------------------------------------------
-class attributes
+class BEAUTY_EXPORT attributes
 {
 public:
     using attribute_storage = std::unordered_map<std::string, attribute>;

--- a/include/beauty/client.hpp
+++ b/include/beauty/client.hpp
@@ -9,6 +9,7 @@
 #include <beauty/url.hpp>
 #include <beauty/websocket_handler.hpp>
 #include <beauty/websocket_client.hpp>
+#include <beauty/export.hpp>
 
 #include <boost/asio.hpp>
 #include <boost/beast.hpp>
@@ -31,7 +32,7 @@ using session_client_https = session_client<true>;
 #endif
 
 // --------------------------------------------------------------------------
-class client
+class BEAUTY_EXPORT client
 {
 public:
     using client_cb = std::function<void(boost::system::error_code, beauty::response&&)>;

--- a/include/beauty/exception.hpp
+++ b/include/beauty/exception.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <boost/beast/http/status.hpp>
+#include <beauty/export.hpp>
 
 #include <stdexcept>
 #include <string>
@@ -13,7 +14,7 @@ class request;
 class response;
 
 // --------------------------------------------------------------------------
-class exception : public std::exception {
+class BEAUTY_EXPORT exception : public std::exception {
 public:
     explicit exception(std::string message = "") : _message(std::move(message)) {}
 
@@ -40,7 +41,7 @@ protected:
 namespace http_error {
 
 #define DEFINE_BEAUTY_EXCEPTION(NAME) \
-class  NAME  : public beauty::exception { \
+class BEAUTY_EXPORT NAME : public beauty::exception { \
 public: explicit NAME(std::string message = "") : exception(beast::http::status::NAME, std::move(message)) {} }
 
 // Client - 400

--- a/include/beauty/route.hpp
+++ b/include/beauty/route.hpp
@@ -5,6 +5,7 @@
 #include <beauty/swagger.hpp>
 #include <beauty/websocket_context.hpp>
 #include <beauty/websocket_handler.hpp>
+#include <beauty/export.hpp>
 
 #include <vector>
 #include <string>
@@ -19,7 +20,7 @@ namespace beauty
 using route_cb = std::function<void(const beauty::request& req, beauty::response& res)>;
 
 // --------------------------------------------------------------------------
-class route
+class BEAUTY_EXPORT route
 {
 public:
     explicit route(const std::string& path, route_cb&& cb = [](const auto& req, auto& res){});

--- a/include/beauty/router.hpp
+++ b/include/beauty/router.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <beauty/route.hpp>
+#include <beauty/export.hpp>
 
 #include <boost/beast.hpp>
 
@@ -9,7 +10,7 @@ namespace beast = boost::beast;
 namespace beauty
 {
 // --------------------------------------------------------------------------
-class router {
+class BEAUTY_EXPORT router {
 public:
     using routes = std::unordered_map<beast::http::verb, std::vector<route>>;
 

--- a/include/beauty/server.hpp
+++ b/include/beauty/server.hpp
@@ -6,13 +6,14 @@
 #include <beauty/acceptor.hpp>
 #include <beauty/endpoint.hpp>
 #include <beauty/swagger.hpp>
+#include <beauty/export.hpp>
 
 #include <string>
 
 namespace beauty
 {
 // --------------------------------------------------------------------------
-class server
+class BEAUTY_EXPORT server
 {
 public:
     // Avoid PATH duplication when adding multiple verbs to the same route (PATH)

--- a/include/beauty/sha1.hpp
+++ b/include/beauty/sha1.hpp
@@ -15,6 +15,8 @@
         -- Volker Grabsch <vog@notjusthosting.com>
 */
 
+#include <beauty/export.hpp>
+
 #include <iostream>
 #include <array>
 #include <cstdint>
@@ -24,7 +26,7 @@ namespace beauty {
 
 using digest_type = std::array<uint8_t, 20>;
 
-class SHA1
+class BEAUTY_EXPORT SHA1
 {
 public:
     SHA1();

--- a/include/beauty/signal.hpp
+++ b/include/beauty/signal.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <beauty/application.hpp>
+#include <beauty/export.hpp>
 
 #include <boost/asio.hpp>
 
@@ -12,7 +13,7 @@ namespace beauty
 using signal_cb = std::function<void(int signal)>;
 
 // --------------------------------------------------------------------------
-class signal_set : public std::enable_shared_from_this<signal_set>
+class BEAUTY_EXPORT signal_set : public std::enable_shared_from_this<signal_set>
 {
 public:
     explicit signal_set(signal_cb&& cb);
@@ -27,6 +28,6 @@ private:
 };
 
 // --------------------------------------------------------------------------
-void signal(int s, signal_cb&& cb);
-void signal(std::initializer_list<int>&& signals, signal_cb&& cb);
+BEAUTY_EXPORT void signal(int s, signal_cb&& cb);
+BEAUTY_EXPORT void signal(std::initializer_list<int>&& signals, signal_cb&& cb);
 }

--- a/include/beauty/swagger.hpp
+++ b/include/beauty/swagger.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <beauty/export.hpp>
+
 #include <string>
 #include <vector>
 
@@ -31,6 +33,7 @@ struct route_info {
 };
 
 // --------------------------------------------------------------------------
+BEAUTY_EXPORT
 std::string
 swagger_path(const beauty::route& route);
 

--- a/include/beauty/timer.hpp
+++ b/include/beauty/timer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <beauty/application.hpp>
+#include <beauty/export.hpp>
 
 #include <boost/asio.hpp>
 
@@ -13,7 +14,7 @@ using duration = std::chrono::steady_clock::duration;
 using timer_cb = std::function<bool()>;
 
 // --------------------------------------------------------------------------
-class timer : public std::enable_shared_from_this<timer>
+class BEAUTY_EXPORT timer : public std::enable_shared_from_this<timer>
 {
 public:
     template<typename Callback>

--- a/include/beauty/url.hpp
+++ b/include/beauty/url.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <beauty/export.hpp>
+
 #include <string>
 #include <string_view>
 
@@ -16,7 +18,7 @@ namespace beauty
 //    http://login@localhost.com/path
 //    http://login:pwd@localhost.com/path
 // --------------------------------------------------------------------------
-class url
+class BEAUTY_EXPORT url
 {
 public:
     url() = default;

--- a/include/beauty/utils.hpp
+++ b/include/beauty/utils.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <boost/system/system_error.hpp>
+#include <beauty/export.hpp>
 
 #include <vector>
 #include <string>
@@ -15,18 +16,21 @@ namespace helper {
 //---------------------------------------------------------------------------
 // Returns a bad request response
 //---------------------------------------------------------------------------
+BEAUTY_EXPORT
 std::shared_ptr<response>
 bad_request(const beauty::request& req, const char* message);
 
 //---------------------------------------------------------------------------
 // Returns a not found response
 //---------------------------------------------------------------------------
+BEAUTY_EXPORT
 std::shared_ptr<response>
 not_found(const beauty::request& req);
 
 //---------------------------------------------------------------------------
 // Returns a server error response
 //---------------------------------------------------------------------------
+BEAUTY_EXPORT
 std::shared_ptr<response>
 server_error(const beauty::request& req, const char* what);
 }
@@ -34,22 +38,25 @@ server_error(const beauty::request& req, const char* what);
 //---------------------------------------------------------------------------
 // Report a failure
 //---------------------------------------------------------------------------
+BEAUTY_EXPORT
 void
 fail(boost::system::error_code ec, const char* what);
 
 // --------------------------------------------------------------------------
+BEAUTY_EXPORT
 std::vector<std::string_view>
 split(const std::string& str, char sep = '/');
 
+BEAUTY_EXPORT
 std::vector<std::string_view>
 split(const std::string_view& str_view, char sep = '/');
 
 // --------------------------------------------------------------------------
-std::string escape(const std::string& s);
-std::string unescape(const std::string& s);
-std::string make_uuid();
+BEAUTY_EXPORT std::string escape(const std::string& s);
+BEAUTY_EXPORT std::string unescape(const std::string& s);
+BEAUTY_EXPORT std::string make_uuid();
 
 // --------------------------------------------------------------------------
-void thread_set_name(const std::string& name);
+BEAUTY_EXPORT void thread_set_name(const std::string& name);
 
 }

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -133,6 +133,7 @@ install(TARGETS beauty
     EXPORT BeautyConfig
     ARCHIVE  DESTINATION lib
     LIBRARY  DESTINATION lib
+    RUNTIME  DESTINATION bin
 )
 
 install(EXPORT BeautyConfig

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -50,6 +50,14 @@ set_target_properties(beauty
         VERSION ${VERSION}
 )
 
+include(GenerateExportHeader)
+generate_export_header(beauty EXPORT_FILE_NAME ${CMAKE_BINARY_DIR}/src/beauty/export.hpp)
+
+target_compile_definitions(beauty
+	PUBLIC
+		"$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:BEAUTY_STATIC_DEFINE>"
+)
+
 if(BEAUTY_ENABLE_OPENSSL)
     target_compile_definitions(beauty
         PUBLIC
@@ -113,7 +121,7 @@ endif()
 
 configure_file(./version.hpp.in ${CMAKE_BINARY_DIR}/src/beauty/version.hpp)
 
-install(FILES "${CMAKE_BINARY_DIR}/src/beauty/version.hpp"
+install(FILES "${CMAKE_BINARY_DIR}/src/beauty/version.hpp" "${CMAKE_BINARY_DIR}/src/beauty/export.hpp"
         DESTINATION include/beauty
 )
 install(

--- a/tests/client/CMakeLists.txt
+++ b/tests/client/CMakeLists.txt
@@ -10,4 +10,5 @@ add_test_executable(
         ../include
     LIBRARIES
         beauty::beauty
+        Boost::json
 )


### PR DESCRIPTION
User may call CMake with -DBUILD_SHARED_LIBS:BOOL=ON and CMake will create a shared library.
On Windows this was not supported because symbol export declarations were missing.
Export macros are now generated by CMake. Examples and Test applications build as well now using import library on linking. Static build is of couse still available.