### PR TITLE
Fix handling of pthread_setname_np on macOS

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -191,7 +191,7 @@ make_uuid()
 //---------------------------------------------------------------------------
 void
 thread_set_name(const std::string& name) {
-#ifdef LINUX
+#if LINUX && _GNU_SOURCE
     constexpr int TASK_COMM_LEN = 16;
 
     char thread_name[TASK_COMM_LEN] = "";


### PR DESCRIPTION
Version 1.0.2 fails to build on macOS due to `pthread_setname_np` not being available there as it's a non-standard GNU extension.

This cropped up in a version bump for the Conan recipe: https://github.com/conan-io/conan-center-index/pull/22319