### PR TITLE
Add Conan 2.x support for recipe and more

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,11 +1,13 @@
 cmake_minimum_required(VERSION 3.21)
 
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}")
+set(VERSION 1.0.4)
 
-project(Beauty LANGUAGES CXX VERSION 1.0.4)
+project(Beauty LANGUAGES CXX VERSION ${VERSION})
 
 option(BEAUTY_ENABLE_OPENSSL "Enable OpenSSL support" OFF)
 option(BEAUTY_BUILD_EXAMPLES "Build examples" ON)
+option(BUILD_TESTING "Build tests" ON)
 
 find_package(Boost CONFIG REQUIRED)
 if (BEAUTY_ENABLE_OPENSSL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,33 +2,14 @@ cmake_minimum_required(VERSION 3.21)
 
 LIST(APPEND CMAKE_MODULE_PATH "${CMAKE_BINARY_DIR}")
 
-project(Beauty)
-set(VERSION 1.0.1-rc)
+project(Beauty LANGUAGES CXX VERSION 1.0.4)
 
-# C++
-set(CMAKE_CXX_STANDARD 17)
-set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSION OFF)
+option(BEAUTY_ENABLE_OPENSSL "Enable OpenSSL support" OFF)
+option(BEAUTY_BUILD_EXAMPLES "Build examples" ON)
 
-# Some packages...
-if (NOT DEFINED CONAN OR CONAN)
-    if (NOT EXISTS ${CMAKE_BINARY_DIR}/conan_toolchain.cmake)
-        message(FATAL_ERROR "In Conan mode, you must run a 'conan install' command")
-    endif()
-
-    include(${CMAKE_BINARY_DIR}/conan_toolchain.cmake)
-
-    find_package(Boost CONFIG REQUIRED)
-    if (BEAUTY_ENABLE_OPENSSL)
-        find_package(OpenSSL CONFIG REQUIRED)
-    endif()
-else()
-    find_package(Boost REQUIRED COMPONENTS json)
-
-    if (BEAUTY_ENABLE_OPENSSL)
-        find_package(OpenSSL REQUIRED)
-        add_library(openssl::openssl ALIAS OpenSSL::SSL)
-    endif()
+find_package(Boost CONFIG REQUIRED)
+if (BEAUTY_ENABLE_OPENSSL)
+    find_package(OpenSSL CONFIG REQUIRED)
 endif()
 
 if(UNIX)
@@ -38,9 +19,12 @@ endif()
 
 # Beauty
 add_subdirectory(src)
-add_subdirectory(examples)
 
-if (NOT CONAN_IN_LOCAL_CACHE)
+if (BEAUTY_BUILD_EXAMPLES)
+    add_subdirectory(examples)
+endif()
+
+if (BUILD_TESTING)
   include(CTest)
   enable_testing()
   add_subdirectory(tests)

--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ Further examples can be found into the binaries directory at the root of the pro
 
 ## Build
 
-Beauty depends Boost.Beast and OpenSsl. You can rely on Conan to get the package or
+Beauty depends Boost.Beast and OpenSsl. You can rely on Conan 2.x to get the package or
 only the FindPackage from CMake.
 
 ### Linux

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ int main()
             std::cout << response.body() << std::endl;
         } else {
             std::cout << response.status() << std::endl;
-        }   
+        }
     } else {
         // An error occurred
         std::cout << ec << ": " << ec.message() << std::endl;
@@ -287,35 +287,55 @@ For Conan, you need to provide a profile, here, using default as profile.
 
 ```shell
 git clone https://github.com/dfleury2/beauty.git
-cd beauty
-mkdir build && cd build
-conan install .. -pr default -pr:b default -b missing -of ..
-cmake .. -DCMAKE_BUILD_TYPE=Release
-cmake --build . -j4
+cd beauty/
+conan install . -pr default -pr:b default -b missing -of build
+cmake -S . -B build --preset conan-release
+cmake --build build --preset conan-release
 ```
 
 If you do not want to use Conan, you can try:
 
 ```shell
 git clone https://github.com/dfleury2/beauty.git
-cd beauty
-mkdir build && cd build
-cmake .. -DCMAKE_BUILD_TYPE=Release -DCONAN=false
-cmake --build . -j4
+cd beauty/
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build
 ```
 
 Hope your the dependencies are found on your Linux.
 
 If you want to disable openssl:
 ```shell
-conan install .. -pr default -pr:b default -o beauty:openssl=False -of . -r conancenter -b missing
-````
+conan install . -o "&:openssl=False" -pr default -pr:b default -b missing -of build
+```
+
+In case you want to build and run unit tests, you can use the following command:
+
+```shell
+git clone https://github.com/dfleury2/beauty.git
+cd beauty/
+cmake -S . -B build -DBUILD_TESTING=ON
+cmake --build build
+cd build/tests/
+ctest
+```
+
+To build the examples, you can use the following command:
+
+```shell
+git clone https://github.com/dfleury2/beauty.git
+cd beauty/
+cmake -S . -B build -DBEAUTY_BUILD_EXAMPLES=ON
+cmake --build build
+cd build/examples/
+./beauty_application # or any other example
+```
 
 ### Linux Makefile
 
 For those who want just a simple Makefile without bothering with dependency management,
 in the `docs` directory, there is an example of a simple one-shot Makefile to create a
-library archive to be used in another project. This Makefile must used (and moved) at the 
+library archive to be used in another project. This Makefile must used (and moved) at the
 at the project root.
 
 ```makefile
@@ -342,7 +362,7 @@ $(LIB): version.hpp $(OBJS)
 	ar -r $@ $(OBJS)
 
 version.hpp:
-	VERSION=1.0.0-rc1 envsubst < src/version.hpp.in > ./include/beauty/version.hpp
+	VERSION=1.0.4 envsubst < src/version.hpp.in > ./include/beauty/version.hpp
 
 clean:
 	rm -f libeauty.a ./src/*.o ./include/beauty/version.hpp
@@ -357,15 +377,14 @@ automatically for VS2022.
 ```shell
 git clone https://github.com/dfleury2/beauty.git
 cd beauty
-mkdir build-vs2019 && cd build-vs2019
-conan install .. -pr vs2019 -pr:b vs2019 -b missing -of .
-cmake ..
-cmake --build . --config Release
+conan install . -o "&:openssl=False" -pr vs2019 -pr:b vs2019 -b missing -of build
+cmake -S . -B build --preset conan-release
+cmake --build build --config Release
 ```
 
-The binaries will be created in the `examples\Release` directory.cd ..
+The binaries will be created in the `build\examples\Release` directory.cd ..
 
-or for Visual Studio 2022. Unfortunately at this time, I did not succeed to compile 
+or for Visual Studio 2022. Unfortunately at this time, I did not succeed to compile
 openssl with compiler.version = 17...
 
 

--- a/conanfile.py
+++ b/conanfile.py
@@ -88,8 +88,11 @@ class BeautyConan(ConanFile):
         copy(self, "LICENSE", dst=os.path.join(self.package_folder, "licenses"), src=self.source_folder)
         cmake = CMake(self)
         cmake.install()
+        copy(self, "*", dst=os.path.join(self.package_folder, "examples"),
+                src=os.path.join(self.build_folder, "examples"),
+                excludes=["*.cpp", "*.hpp", "*.pem", "*.txt", "*.cmake", "CMakeFiles", "bazel"])
+        copy(self, "*.t", dst=os.path.join(self.package_folder, "tests"), src=os.path.join(self.build_folder, "t"))
         rmdir(self, os.path.join(self.package_folder, "lib", "cmake"))
-        copy(self, "*", dst=os.path.join(self.package_folder, "examples"), src=os.path.join(self.build_folder, "examples"))
 
     def layout(self):
         self.cpp_info.libs = ["beauty"]

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,8 @@ from conan.tools.build import check_min_cppstd
 
 import os
 
-# -----------------------------------------------------------------------------
+required_conan_version = ">=2.0.9"
+
 class BeautyConan(ConanFile):
     name            = "beauty"
     description     = "HTTP Server above Boost.Beast"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,8 +46,13 @@ set_target_properties(beauty
         LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
         ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib
         OUTPUT_NAME beauty
-        SOVERSION ${VERSION}
-        VERSION ${VERSION}
+        SOVERSION ${CMAKE_PROJECT_VERSION}
+        VERSION ${CMAKE_PROJECT_VERSION}
+)
+
+target_compile_features(beauty
+    PUBLIC
+        cxx_std_17
 )
 
 include(GenerateExportHeader)
@@ -100,18 +105,22 @@ target_link_libraries(beauty
 if (BEAUTY_ENABLE_OPENSSL)
     target_link_libraries(beauty
         PUBLIC
-            openssl::openssl
+            OpenSSL::SSL
             ${CMAKE_DL_LIBS}
     )
 endif()
-
 
 if(UNIX)
     target_link_libraries(beauty
         PUBLIC
             Threads::Threads
-            stdc++fs
     )
+    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        target_link_libraries(beauty
+            PUBLIC
+                stdc++fs
+        )
+    endif()
 elseif(WIN32)
     target_link_libraries(beauty
         PUBLIC
@@ -131,13 +140,13 @@ install(
 
 install(TARGETS beauty
     EXPORT BeautyConfig
-    ARCHIVE  DESTINATION lib
-    LIBRARY  DESTINATION lib
-    RUNTIME  DESTINATION bin
+    ARCHIVE  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    LIBRARY  DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    RUNTIME  DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
 
 install(EXPORT BeautyConfig
     FILE BeautyConfig.cmake
     NAMESPACE beauty::
-    DESTINATION lib/cmake/beauty
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/beauty
 )


### PR DESCRIPTION
Hi!

After checking the project to update the PR https://github.com/conan-io/conan-center-index/pull/24364 I noted the Conan recipe in this repository is Conan 1.x only. It's recommended updating its support to Conan 2.x, because the version 1.x is in the way to be deprecated and no longer receives new features (only important bugfixes and security patches).

So in this PR I did the follow changes:

In CMakeLists.txt

- Replaced forced CMAKE_CXX_STANDARD by [target_compile_features](https://cmake.org/cmake/help/latest/command/target_compile_features.html) so users (and Conan) can configure to use C++20
- Replaced VERSION variable by [CMAKE_PROJECT_VERSION](https://cmake.org/cmake/help/latest/variable/CMAKE_PROJECT_VERSION.html), so you can use the standard feature instead
- Externalized BEAUTY_ENABLE_OPENSSL as option. Disable by default, because current condition is off.
- Add new option BEAUTY_BUILD_EXAMPLES (disabled by default) to build or not example. It gives more flexibility when you want to build beauty library and tests only
- Use [BUILD_TESTING](https://cmake.org/cmake/help/latest/command/enable_testing.html#command:enable_testing) CMake standard definition to build tests
- Removed redefined cmake target openssl::openssl, now managed by Conan CMakeDeps
- Add condition to link stdc++fs only when using GNU g++ (Clang uses [libc++fs](https://releases.llvm.org/8.0.0/projects/libcxx/docs/UsingLibcxx.html#using-filesystem-and-libc-fs))
- Using standard CMake variables for [destination folders](https://cmake.org/cmake/help/latest/command/install.html#signatures)


In conanfile.py

- Removed old imports related to Conan 1.x like conans
- Requires Conan 2.0.9 as minimum version (is 1 year old this version)
- Add support to build and run unit tests directly from the recipe (tests are not packaged)
- Add support to build examples (examples are not package)
- Add check to validate C++17 as minimal compiler.cppstd
- Consume pthread and crypt32 as system libraries when needed
- Export the compiler definition BEAUTY_ENABLE_OPENSSL when using openssl

In README.md

- Updated instructions using Conan 2.x and [CMake Presets](https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html)
- Add new instruction how to build with tests
- Add new instruction how to build examples 

As this project does not run a CI (I could send in a future PR support to Github Actions if you want), I built locally on MacOS. Here is my build log:

[build.log](https://github.com/user-attachments/files/15873722/build.log)
