### PR TITLE
fix compilation with Boost 1.86

### DIFF
--- a/include/beauty/websocket_client.hpp
+++ b/include/beauty/websocket_client.hpp
@@ -70,7 +70,7 @@ private:
         // Make the connection on the IP address we get from a lookup
         beast::get_lowest_layer(_websocket).async_connect(
                 results,
-                [me = this->shared_from_this()](auto ec, auto&& ep) {
+                [me = this->shared_from_this()](auto ec, asio::ip::tcp::resolver::results_type::endpoint_type ep) {
                     me->on_connect(ec, ep);
                 });
     }


### PR DESCRIPTION
There was an interface change in Boost 1.86. Now we do not have only an IteratorConnectHandler. Boost 1.86 adds a RangeConnectHandler. Compiler now selects another handler type for 'auto&&'. Hence we need to clarify expected handler type here.

Compilers tested: MSVC 16 (VS 2019) and MSVC 17 (VS2022)

Should also work on older revisions of Boost, although untested.
