### PR TITLE
Search for Boost::json component in cmake

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: '3.10'
 
       - name: Cache Conan packages
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4
         env:
           cache-name: cache-conan-packages
         with:

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -17,7 +17,7 @@ jobs:
           cache: 'pip'
 
       - name: Cache Conan packages
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4
         env:
           cache-name: cache-conan-packages
         with:

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -49,3 +49,22 @@ jobs:
       - name: Test
         working-directory: ${{ github.workspace }}/build
         run: ctest --output-on-failure
+
+  ci-linux-gcc-13-distribution-boost:
+    name: ci-linux-g++-13-distribution-boost-static-release
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install C++ tools and distribution boost libraries
+        run: sudo apt-get install -y libboost-all-dev ninja-build
+
+      - name: Build
+        run: |
+          cmake -S . -B ${{ github.workspace }}/build -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS:BOOL=OFF -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
+          cmake --build ${{ github.workspace }}/build
+
+      - name: Test
+        working-directory: ${{ github.workspace }}/build
+        run: ctest --output-on-failure

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -20,7 +20,7 @@ jobs:
           cache: 'pip'
 
       - name: Cache Conan packages
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4
         env:
           cache-name: cache-conan-packages
         with:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -20,7 +20,7 @@ jobs:
           cache: 'pip'
 
       - name: Cache Conan packages
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4
         env:
           cache-name: cache-conan-packages
         with:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ option(BEAUTY_ENABLE_OPENSSL "Enable OpenSSL support" OFF)
 option(BEAUTY_BUILD_EXAMPLES "Build examples" ON)
 option(BUILD_TESTING "Build tests" ON)
 
-find_package(Boost CONFIG REQUIRED)
+find_package(Boost CONFIG COMPONENTS json REQUIRED)
 if (BEAUTY_ENABLE_OPENSSL)
     find_package(OpenSSL CONFIG REQUIRED)
 endif()


### PR DESCRIPTION
**Depends on https://github.com/dfleury2/beauty/pull/45, that one should be merged first**

This fixes build when using distribution boost packages on e.g. Debian 13, but also likely in other environments.

The PR also adds a github workflow to test distribution packages on Ubuntu.

Reproduction steps:

```
sudo docker run -it debian:trixie /bin/bash
```

Inside:

```
apt update && apt install git libboost-all-dev g++ cmake
git clone https://github.com/dfleury2/beauty
cd beauty
mkdir build
cd build
cmake ..
```

Current output:

```

-- The CXX compiler identification is GNU 14.2.0
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_VISIBILITY - Success
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY
-- Performing Test COMPILER_HAS_HIDDEN_INLINE_VISIBILITY - Success
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR
-- Performing Test COMPILER_HAS_DEPRECATED_ATTR - Success
-- Configuring done (2.2s)
CMake Error at tests/CMakeHelper.cmake:21 (target_link_libraries):
  Target "tst_client" links to:

    Boost::json

  but the target was not found.  Possible reasons include:

    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.

Call Stack (most recent call first):
  tests/client/CMakeLists.txt:1 (add_test_executable)


-- Generating done (0.3s)
CMake Generate step failed.  Build files cannot be regenerated correctly.
```
