### PR TITLE
github: Fix build by depending actions/cache@v4

### DIFF
--- a/.github/workflows/ci-conan.yml
+++ b/.github/workflows/ci-conan.yml
@@ -19,7 +19,7 @@ jobs:
           python-version: '3.10'
 
       - name: Cache Conan packages
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4
         env:
           cache-name: cache-conan-packages
         with:

--- a/.github/workflows/ci-linux.yml
+++ b/.github/workflows/ci-linux.yml
@@ -17,7 +17,7 @@ jobs:
           cache: 'pip'
 
       - name: Cache Conan packages
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4
         env:
           cache-name: cache-conan-packages
         with:

--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -20,7 +20,7 @@ jobs:
           cache: 'pip'
 
       - name: Cache Conan packages
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4
         env:
           cache-name: cache-conan-packages
         with:

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -20,7 +20,7 @@ jobs:
           cache: 'pip'
 
       - name: Cache Conan packages
-        uses: actions/cache@v4.0.2
+        uses: actions/cache@v4
         env:
           cache-name: cache-conan-packages
         with:


### PR DESCRIPTION
Currently build fails with:

Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v4.0.2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more:
https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down

See e.g. https://github.com/dfleury2/beauty/actions/runs/16135225798/job/45530064115?pr=44

Note that upgrading to v4.0.3 fails as well: https://github.com/dfleury2/beauty/actions/runs/16135312210/job/45530318515?pr=45

Seems like someone didn't use a regex correctly.