### PR TITLE
github: Install ninja manually on MacOS

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -10,8 +10,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install Ninja
-        uses: seanmiddleditch/gha-setup-ninja@v4
+      - name: Install ninja
+        run: brew install ninja
 
       - name: Configure Python 3.10
         uses: actions/setup-python@v5


### PR DESCRIPTION
Currently CMake is not able to find ninja:

CMake Error: CMake was unable to find a build program corresponding to "Ninja".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a different build tool.

From https://github.com/dfleury2/beauty/actions/runs/16251489637/job/45881783746

This means either seanmiddleditch/gha-setup-ninja or current build script is broken for some reason. Since upcoming MacOS 15 images will include ninja by default and seanmiddleditch/gha-setup-ninja has been archived, just go the easiest way and install ninja via brew.