### PR TITLE
Use shared ownership for routes

### DIFF
--- a/include/beauty/router.hpp
+++ b/include/beauty/router.hpp
@@ -12,7 +12,7 @@ namespace beauty
 // --------------------------------------------------------------------------
 class BEAUTY_EXPORT router {
 public:
-    using routes = std::unordered_map<beast::http::verb, std::vector<route>>;
+    using routes = std::unordered_map<beast::http::verb, std::vector<std::shared_ptr<route>>>;
 
     void add_route(beast::http::verb v, route&& r);
 

--- a/include/beauty/session.hpp
+++ b/include/beauty/session.hpp
@@ -239,7 +239,7 @@ private:
 
         // Try to match a route for this request target
         for(auto&& route : found_method->second) {
-            if (route.match(_request, _is_websocket)) {
+            if (route->match(_request, _is_websocket)) {
                 // Match will update parameters request from the URL
                 try {
                     if (_is_websocket) {
@@ -252,7 +252,7 @@ private:
                         res->set(beast::http::field::server, BEAUTY_PROJECT_VERSION);
                         res->keep_alive(_request.keep_alive());
 
-                        route.execute(_request, *res); // Call the route user handler
+                        route->execute(_request, *res); // Call the route user handler
 
                         return res;
                     }

--- a/include/beauty/websocket_session.hpp
+++ b/include/beauty/websocket_session.hpp
@@ -9,7 +9,6 @@
 #include <boost/beast/websocket.hpp>
 #include <boost/asio.hpp>
 
-#include <iostream>
 #include <memory>
 #include <deque>
 
@@ -23,7 +22,7 @@ namespace beauty {
 // --------------------------------------------------------------------------
 class websocket_session : public std::enable_shared_from_this<websocket_session> {
 public:
-    explicit websocket_session(asio::ip::tcp::socket&& socket, const beauty::route& route) :
+    explicit websocket_session(asio::ip::tcp::socket&& socket, std::shared_ptr<beauty::route> route) :
             _websocket(std::move(socket)),
             _route(route)
     {}
@@ -31,7 +30,7 @@ public:
     ~websocket_session()
     {
         if (!_ws_context.uuid.empty()) {
-            _route.disconnect(_ws_context);
+            _route->disconnect(_ws_context);
         }
     }
 
@@ -40,7 +39,7 @@ public:
         _ws_context.remote_endpoint = _websocket.next_layer().socket().remote_endpoint();
         _ws_context.local_endpoint = _websocket.next_layer().socket().local_endpoint();
         _ws_context.target = std::string{req.target()};
-        _ws_context.route_path = _route.path();
+        _ws_context.route_path = _route->path();
         _ws_context.attributes = req.get_attributes();
 
         _websocket.set_option(
@@ -70,7 +69,7 @@ public:
 private:
     beast::websocket::stream<beast::tcp_stream> _websocket;
     beast::flat_buffer _buffer;
-    const beauty::route& _route;
+    std::shared_ptr<beauty::route> _route;
     ws_context  _ws_context;
 
     struct message {
@@ -91,7 +90,7 @@ private:
         _ws_context.uuid = make_uuid();
         //std::cout << "websocket_session: " << _ws_context.uuid << " - on accept" << std::endl;
 
-        _route.connect(_ws_context);
+        _route->connect(_ws_context);
 
         do_read();
     }
@@ -117,7 +116,7 @@ private:
             return fail(ec, "read");
         }
 
-        _route.receive(_ws_context, static_cast<const char*>(_buffer.cdata().data()), _buffer.size(), _websocket.got_text());
+        _route->receive(_ws_context, static_cast<const char*>(_buffer.cdata().data()), _buffer.size(), _websocket.got_text());
         _buffer.consume(_buffer.size());
 
         do_read();

--- a/src/router.cpp
+++ b/src/router.cpp
@@ -7,12 +7,12 @@ namespace beauty {
 void
 router::add_route(beast::http::verb v, route&& r)
 {
-    _routes[v].push_back(std::move(r));
+    _routes[v].push_back(std::make_shared<beauty::route>(std::move(r)));
 
     std::sort(_routes[v].begin(), _routes[v].end(),
-            [](const beauty::route& lh, const beauty::route& rh) {
-                const auto lh_segment_count = lh.segments().size();
-                const auto rh_segment_count = rh.segments().size();
+            [](const auto& lh, const auto& rh) {
+                const auto lh_segment_count = lh->segments().size();
+                const auto rh_segment_count = rh->segments().size();
 
                 if (lh_segment_count < rh_segment_count) return true;
                 if (lh_segment_count > rh_segment_count) return false;
@@ -20,8 +20,8 @@ router::add_route(beast::http::verb v, route&& r)
                 int lh_cost = 0, rh_cost = 0;
                 int power = 1;
                 for (int i = lh_segment_count - 1; i >= 0; --i) {
-                    if (lh.segments()[i][0] == ':') lh_cost += power;
-                    if (rh.segments()[i][0] == ':') rh_cost += power;
+                    if (lh->segments()[i][0] == ':') lh_cost += power;
+                    if (rh->segments()[i][0] == ':') rh_cost += power;
                     power *= 2;
                 }
 

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -226,15 +226,15 @@ server::enable_swagger(const char* swagger_entrypoint)
 
         boost::json::object paths;
         for (const auto&[verb, routes] : _router) {
-            for (auto&& route : routes) {
+            for (const auto& route : routes) {
                 boost::json::object description = {
-                        {"description", route.route_info().description}
+                        {"description", route->route_info().description}
                 };
 
-                if (!route.route_info().route_parameters.empty()) {
+                if (!route->route_info().route_parameters.empty()) {
                     description["parameters"] = boost::json::array();
                     boost::json::array parameters;
-                    for (const auto& param : route.route_info().route_parameters) {
+                    for (const auto& param : route->route_info().route_parameters) {
                         parameters.push_back(boost::json::object{
                             {"name",        param.name},
                             {"in",          param.in},
@@ -249,7 +249,7 @@ server::enable_swagger(const char* swagger_entrypoint)
                     description["parameters"] = std::move(parameters);
                 }
 
-                paths[swagger_path(route)].emplace_object()[to_lower(std::string(to_string(verb)))] = std::move(description);
+                paths[swagger_path(*route)].emplace_object()[to_lower(std::string(to_string(verb)))] = std::move(description);
             }
         }
 

--- a/tests/router/test_router.cpp
+++ b/tests/router/test_router.cpp
@@ -7,9 +7,9 @@ namespace {
 auto route_matcher = [](const beauty::router& router, beauty::request& req) {
     for (const auto&[_, routes]: router) {
         for (const auto& r: routes) {
-            if (r.match(req)) {
+            if (r->match(req)) {
                 beauty::response res;
-                r.execute(req, res);
+                r->execute(req, res);
             }
         }
     }


### PR DESCRIPTION
This should fix use-after-free when using external IO context. When there are in-flight connections, destroying server or application will still leave active connections. Disconnection will cause a reliable use-after-free.

This is not a great fix because the user will still need to ensure that their ws_handler instances outlive all connections. However at least in this case there's chance to do something.

The following is a ASAN report:
```
================================================================= ==1742057==ERROR: AddressSanitizer: heap-use-after-free on address 0x512000003270 at pc 0x559c93dc9eef bp 0x7fff539b5fb0 sp 0x7fff539b5fa8 READ of size 8 at 0x512000003270 thread T0
    #0 0x559c93dc9eee in std::_Function_base::_M_empty() const /usr/include/c++/14/bits/std_function.h:247
    #1 0x559c93f1dd3b in std::function<void (beauty::ws_context const&)>::operator()(beauty::ws_context const&) const /usr/include/c++/14/bits/std_function.h:589
    #2 0x559c94674fc2 in beauty::route::disconnect(beauty::ws_context const&) const .../beauty/include/beauty/route.hpp:44
    #3 0x559c946770f0 in beauty::websocket_session::~websocket_session() .../beauty/include/beauty/websocket_session.hpp:34
    #4 0x559c9492a5e5 in void std::_Destroy<beauty::websocket_session>(beauty::websocket_session*) /usr/include/c++/14/bits/stl_construct.h:151
    #5 0x559c94925d16 in void std::allocator_traits<std::allocator<void> >::destroy<beauty::websocket_session>(std::allocator<void>&, beauty::websocket_session*) /usr/include/c++/14/bits/alloc_traits.h:720
    #6 0x559c94925d16 in std::_Sp_counted_ptr_inplace<beauty::websocket_session, std::allocator<void>, (__gnu_cxx::_Lock_policy)2>::_M_dispose() /usr/include/c++/14/bits/shared_ptr_base.h:616
    #7 0x559c93ac5f52 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_last_use() /usr/include/c++/14/bits/shared_ptr_base.h:175
    #8 0x559c93abb35b in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release_last_use_cold() /usr/include/c++/14/bits/shared_ptr_base.h:199
    #9 0x559c93aa0aa0 in std::_Sp_counted_base<(__gnu_cxx::_Lock_policy)2>::_M_release() /usr/include/c++/14/bits/shared_ptr_base.h:353
    #10 0x559c93abb8d9 in std::__shared_count<(__gnu_cxx::_Lock_policy)2>::~__shared_count() /usr/include/c++/14/bits/shared_ptr_base.h:1069
    #11 0x559c93ca770b in std::__shared_ptr<beauty::websocket_session, (__gnu_cxx::_Lock_policy)2>::~__shared_ptr() /usr/include/c++/14/bits/shared_ptr_base.h:1525
    #12 0x559c93ca7779 in std::shared_ptr<beauty::websocket_session>::~shared_ptr() /usr/include/c++/14/bits/shared_ptr.h:175
    #13 0x559c9467905b in beauty::websocket_session::do_read()::{lambda(auto:1, unsigned long)#1}::~do_read() .../beauty/include/beauty/websocket_session.hpp:105
    #14 0x559c9468a781 in boost::beast::async_base<beauty::websocket_session::do_read()::{lambda(auto:1, unsigned long)#1}, boost::asio::any_io_executor, std::allocator<void> >::~async_base() /usr/include/boost/beast/core/async_base.hpp:273
    #15 0x559c9468aa19 in boost::beast::websocket::stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>, true>::read_op<beauty::websocket_session::do_read()::{lambda(auto:1, unsigned long)#1}, boost::beast::basic_flat_buffer<std::allocator<char> > >::~read_op() /usr/include/boost/beast/websocket/impl/read.hpp:732
    #16 0x559c9469b00f in boost::beast::async_base<boost::beast::websocket::stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>, true>::read_op<beauty::websocket_session::do_read()::{lambda(auto:1, unsigned long)#1}, boost::beast::basic_flat_buffer<std::allocator<char> > >, boost::asio::any_io_executor, std::allocator<void> >::~async_base() /usr/include/boost/beast/core/async_base.hpp:273
    #17 0x559c9469b2af in boost::beast::websocket::stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>, true>::read_some_op<boost::beast::websocket::stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>, true>::read_op<beauty::websocket_session::do_read()::{lambda(auto:1, unsigned long)#1}, boost::beast::basic_flat_buffer<std::allocator<char> > >, boost::asio::mutable_buffer>::~read_some_op() /usr/include/boost/beast/websocket/impl/read.hpp:48
    #18 0x559c946c8313 in boost::beast::async_base<boost::beast::websocket::stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>, true>::read_some_op<boost::beast::websocket::stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>, true>::read_op<beauty::websocket_session::do_read()::{lambda(auto:1, unsigned long)#1}, boost::beast::basic_flat_buffer<std::allocator<char> > >, boost::asio::mutable_buffer>, boost::asio::any_io_executor, std::allocator<void> >::~async_base() /usr/include/boost/beast/core/async_base.hpp:273
    #19 0x559c946d03a6 in boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>::ops::transfer_op<true, boost::beast::detail::buffers_pair<true>, boost::beast::websocket::stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>, true>::read_some_op<boost::beast::websocket::stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>, true>::read_op<beauty::websocket_session::do_read()::{lambda(auto:1, unsigned long)#1}, boost::beast::basic_flat_buffer<std::allocator<char> > >, boost::asio::mutable_buffer> >::~transfer_op() /usr/include/boost/beast/core/impl/basic_stream.hpp:217
    #20 0x559c9474632b in boost::asio::detail::binder2<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>::ops::transfer_op<true, boost::beast::detail::buffers_pair<true>, boost::beast::websocket::stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>, true>::read_some_op<boost::beast::websocket::stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>, true>::read_op<beauty::websocket_session::do_read()::{lambda(auto:1, unsigned long)#1}, boost::beast::basic_flat_buffer<std::allocator<char> > >, boost::asio::mutable_buffer> >, boost::system::error_code, unsigned long>::~binder2() /usr/include/boost/asio/detail/bind_handler.hpp:252
    #21 0x559c947469be in boost::asio::detail::reactive_socket_recv_op<boost::beast::buffers_prefix_view<boost::beast::detail::buffers_pair<true> >, boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>::ops::transfer_op<true, boost::beast::detail::buffers_pair<true>, boost::beast::websocket::stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>, true>::read_some_op<boost::beast::websocket::stream<boost::beast::basic_stream<boost::asio::ip::tcp, boost::asio::any_io_executor, boost::beast::unlimited_rate_policy>, true>::read_op<beauty::websocket_session::do_read()::{lambda(auto:1, unsigned long)#1}, boost::beast::basic_flat_buffer<std::allocator<char> > >, boost::asio::mutable_buffer> >, boost::asio::any_io_executor>::do_complete(void*, boost::asio::detail::scheduler_operation*, boost::system::error_code const&, unsigned long) /usr/include/boost/asio/detail/reactive_socket_recv_op.hpp:155
    #22 0x559c93b44ac7 in boost::asio::detail::scheduler_operation::destroy() /usr/include/boost/asio/detail/scheduler_operation.hpp:45
    #23 0x559c93b805cc in void boost::asio::detail::op_queue_access::destroy<boost::asio::detail::scheduler_operation>(boost::asio::detail::scheduler_operation*) /usr/include/boost/asio/detail/op_queue.hpp:47
    #24 0x559c93b67206 in boost::asio::detail::op_queue<boost::asio::detail::scheduler_operation>::~op_queue() /usr/include/boost/asio/detail/op_queue.hpp:81
    #25 0x559c93b574f2 in boost::asio::detail::scheduler::abandon_operations(boost::asio::detail::op_queue<boost::asio::detail::scheduler_operation>&) (...+0x21f74f2) (BuildId: b3de11019d9f1e8ce703b0425d57d649f75e7e74)
    #26 0x559c93b4cfd5 in boost::asio::detail::epoll_reactor::shutdown() (...+0x21ecfd5) (BuildId: b3de11019d9f1e8ce703b0425d57d649f75e7e74)
    #27 0x559c93b414d5 in boost::asio::detail::service_registry::shutdown_services() (...+0x21e14d5) (BuildId: b3de11019d9f1e8ce703b0425d57d649f75e7e74)
    #28 0x559c93b44065 in boost::asio::execution_context::shutdown() /usr/include/boost/asio/impl/execution_context.ipp:41
    #29 0x559c93b5a9f5 in boost::asio::io_context::~io_context() /usr/include/boost/asio/impl/io_context.ipp:58
    <...>

0x512000003270 is located 176 bytes inside of 280-byte region [0x5120000031c0,0x5120000032d8) freed by thread T0 here:
    #0 0x7f7981af6678 in operator delete(void*, unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:164
    #1 0x559c94577981 in std::__new_allocator<beauty::route>::deallocate(beauty::route*, unsigned long) /usr/include/c++/14/bits/new_allocator.h:172
    #2 0x559c94576e48 in std::allocator_traits<std::allocator<beauty::route> >::deallocate(std::allocator<beauty::route>&, beauty::route*, unsigned long) /usr/include/c++/14/bits/alloc_traits.h:550
    #3 0x559c94576e48 in std::_Vector_base<beauty::route, std::allocator<beauty::route> >::_M_deallocate(beauty::route*, unsigned long) /usr/include/c++/14/bits/stl_vector.h:389
    #4 0x559c94576459 in std::_Vector_base<beauty::route, std::allocator<beauty::route> >::~_Vector_base() /usr/include/c++/14/bits/stl_vector.h:368
    #5 0x559c94561b1b in std::vector<beauty::route, std::allocator<beauty::route> >::~vector() /usr/include/c++/14/bits/stl_vector.h:738
    #6 0x559c9452f8b7 in std::pair<boost::beast::http::verb const, std::vector<beauty::route, std::allocator<beauty::route> > >::~pair() /usr/include/c++/14/bits/stl_pair.h:284
    #7 0x559c9451094b in void std::__new_allocator<std::__detail::_Hash_node<std::pair<boost::beast::http::verb const, std::vector<beauty::route, std::allocator<beauty::route> > >, false> >::destroy<std::pair<boost::beast::http::verb const, std::vector<beauty::route, std::allocator<beauty::route> > > >(std::pair<boost::beast::http::verb const, std::vector<beauty::route, std::allocator<beauty::route> > >*) /usr/include/c++/14/bits/new_allocator.h:198
    #8 0x559c9451094b in void std::allocator_traits<std::allocator<std::__detail::_Hash_node<std::pair<boost::beast::http::verb const, std::vector<beauty::route, std::allocator<beauty::route> > >, false> > >::destroy<std::pair<boost::beast::http::verb const, std::vector<beauty::route, std::allocator<beauty::route> > > >(std::allocator<std::__detail::_Hash_node<std::pair<boost::beast::http::verb const, std::vector<beauty::route, std::allocator<beauty::route> > >, false> >&, std::pair<boost::beast::http::verb const, std::vector<beauty::route, std::allocator<beauty::route> > >*) /usr/include/c++/14/bits/alloc_traits.h:597
    #9 0x559c9451094b in std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<boost::beast::http::verb const, std::vector<beauty::route, std::allocator<beauty::route> > >, false> > >::_M_deallocate_node(std::__detail::_Hash_node<std::pair<boost::beast::http::verb const, std::vector<beauty::route, std::allocator<beauty::route> > >, false>*) /usr/include/c++/14/bits/hashtable_policy.h:2046
    #10 0x559c944f2a99 in std::__detail::_Hashtable_alloc<std::allocator<std::__detail::_Hash_node<std::pair<boost::beast::http::verb const, std::vector<beauty::route, std::allocator<beauty::route> > >, false> > >::_M_deallocate_nodes(std::__detail::_Hash_node<std::pair<boost::beast::http::verb const, std::vector<beauty::route, std::allocator<beauty::route> > >, false>*) /usr/include/c++/14/bits/hashtable_policy.h:2068
    #11 0x559c944e1ced in std::_Hashtable<boost::beast::http::verb, std::pair<boost::beast::http::verb const, std::vector<beauty::route, std::allocator<beauty::route> > >, std::allocator<std::pair<boost::beast::http::verb const, std::vector<beauty::route, std::allocator<beauty::route> > > >, std::__detail::_Select1st, std::equal_to<boost::beast::http::verb>, std::hash<boost::beast::http::verb>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::clear() /usr/include/c++/14/bits/hashtable.h:2588
    #12 0x559c944c404d in std::_Hashtable<boost::beast::http::verb, std::pair<boost::beast::http::verb const, std::vector<beauty::route, std::allocator<beauty::route> > >, std::allocator<std::pair<boost::beast::http::verb const, std::vector<beauty::route, std::allocator<beauty::route> > > >, std::__detail::_Select1st, std::equal_to<boost::beast::http::verb>, std::hash<boost::beast::http::verb>, std::__detail::_Mod_range_hashing, std::__detail::_Default_ranged_hash, std::__detail::_Prime_rehash_policy, std::__detail::_Hashtable_traits<false, false, true> >::~_Hashtable() /usr/include/c++/14/bits/hashtable.h:1671
    #13 0x559c944a8723 in std::unordered_map<boost::beast::http::verb, std::vector<beauty::route, std::allocator<beauty::route> >, std::hash<boost::beast::http::verb>, std::equal_to<boost::beast::http::verb>, std::allocator<std::pair<boost::beast::http::verb const, std::vector<beauty::route, std::allocator<beauty::route> > > > >::~unordered_map() /usr/include/c++/14/bits/unordered_map.h:109
    #14 0x559c944a87ff in beauty::router::~router() .../beauty/include/beauty/router.hpp:13
    #15 0x559c94469d50 in beauty::server::~server() .../beauty/src/server.cpp:22
    #16 0x559c93cc1bbc in std::default_delete<beauty::server>::operator()(beauty::server*) const (...+0x2361bbc) (BuildId: b3de11019d9f1e8ce703b0425d57d649f75e7e74)
    #17 0x559c93cb703a in std::unique_ptr<beauty::server, std::default_delete<beauty::server> >::~unique_ptr() (...+0x235703a) (BuildId: b3de11019d9f1e8ce703b0425d57d649f75e7e74)
    <...>

previously allocated by thread T0 here:
    #0 0x7f7981af5778 in operator new(unsigned long) ../../../../src/libsanitizer/asan/asan_new_delete.cpp:95
    #1 0x559c94948909 in std::__new_allocator<beauty::route>::allocate(unsigned long, void const*) /usr/include/c++/14/bits/new_allocator.h:151
    #2 0x559c949463a7 in std::allocator_traits<std::allocator<beauty::route> >::allocate(std::allocator<beauty::route>&, unsigned long) /usr/include/c++/14/bits/alloc_traits.h:515
    #3 0x559c949463a7 in std::_Vector_base<beauty::route, std::allocator<beauty::route> >::_M_allocate(unsigned long) /usr/include/c++/14/bits/stl_vector.h:380
    #4 0x559c949431d7 in void std::vector<beauty::route, std::allocator<beauty::route> >::_M_realloc_append<beauty::route>(beauty::route&&) /usr/include/c++/14/bits/vector.tcc:596
    #5 0x559c94941daa in beauty::route& std::vector<beauty::route, std::allocator<beauty::route> >::emplace_back<beauty::route>(beauty::route&&) /usr/include/c++/14/bits/vector.tcc:123
    #6 0x559c94941025 in std::vector<beauty::route, std::allocator<beauty::route> >::push_back(beauty::route&&) /usr/include/c++/14/bits/stl_vector.h:1301
    #7 0x559c9493ba69 in beauty::router::add_route(boost::beast::http::verb, beauty::route&&) .../beauty/src/router.cpp:10
    #8 0x559c9446c479 in beauty::server::ws(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, beauty::ws_handler&&) .../beauty/src/server.cpp:115
    <...>

SUMMARY: AddressSanitizer: heap-use-after-free /usr/include/c++/14/bits/std_function.h:247 in std::_Function_base::_M_empty() const Shadow bytes around the buggy address:
  0x512000002f80: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fa fa
  0x512000003000: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x512000003080: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x512000003100: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x512000003180: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
=>0x512000003200: fd fd fd fd fd fd fd fd fd fd fd fd fd fd[fd]fd
  0x512000003280: fd fd fd fd fd fd fd fd fd fd fd fa fa fa fa fa
  0x512000003300: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
  0x512000003380: fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd fd
  0x512000003400: fd fd fd fd fd fd fd fd fd fd fa fa fa fa fa fa
  0x512000003480: fa fa fa fa fa fa fa fa fd fd fd fd fd fd fd fd
Shadow byte legend (one shadow byte represents 8 application bytes):
  Addressable:           00
  Partially addressable: 01 02 03 04 05 06 07
  Heap left redzone:       fa
  Freed heap region:       fd
  Stack left redzone:      f1
  Stack mid redzone:       f2
  Stack right redzone:     f3
  Stack after return:      f5
  Stack use after scope:   f8
  Global redzone:          f9
  Global init order:       f6
  Poisoned by user:        f7
  Container overflow:      fc
  Array cookie:            ac
  Intra object redzone:    bb
  ASan internal:           fe
  Left alloca redzone:     ca
  Right alloca redzone:    cb
==1742057==ABORTING
```