### PR TITLE
Fix broken client build when SSL is enabled

### DIFF
--- a/include/beauty/client.hpp
+++ b/include/beauty/client.hpp
@@ -218,7 +218,7 @@ public:
     }
 
     // Low level send request
-    static client_response
+    client_response
     send_request(beauty::request&& req, const beauty::duration& d, const std::string& url);
 
     void


### PR DESCRIPTION
Adding beauty::application as a member of client and using it exclusively made client::send_response nonstatic when SSL is enabled.

Fixes: da6071d46af22e3c76f472473967bda1d2500add

We didn't notice because CI was broken due to unrelated reason at the time.