### PR TITLE
fix deployment of CMake config files for consumers on Windows

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -138,9 +138,7 @@ install(
     DESTINATION include
 )
 
-if(UNIX)
-  include(GNUInstallDirs)
-endif()
+include(GNUInstallDirs)
 
 install(TARGETS beauty
     EXPORT BeautyConfig


### PR DESCRIPTION
On Windows the generated CMake config files for consumers of the library get installed into wrong directory.

These files:
BeautyConfig.cmake
BeautyConfig-debug.cmake
...

are currently installed into <RootDrive>\cmake\beauty

But they have to get installed alongside library and header files.

Problem is: ${CMAKE_INSTALL_LIBDIR} is not set when GNUInstallDirs is not included.
So here is fix:
Include GNUInstallDirs also on Windows.