### PR TITLE
add request body support for swagger, add tags support, udpate swagge…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,7 @@ CMakeUserPresets.json
 venv
 graph_info.json
 conanbuildinfo.txt
+*.o
+*.a
+conan.lock
+conaninfo.txt

--- a/include/beauty/swagger.hpp
+++ b/include/beauty/swagger.hpp
@@ -5,6 +5,9 @@
 #include <string>
 #include <vector>
 
+#include <optional>
+#include <boost/json.hpp>
+
 namespace beauty
 {
 class route;
@@ -27,9 +30,24 @@ struct route_parameter {
 };
 
 // --------------------------------------------------------------------------
+struct body_schema {
+    std::string schema_name; // "text/plain", "application/json", etc. check openapi documentation for all the supported schemas
+    boost::json::object schema;
+};
+
+// --------------------------------------------------------------------------
+struct request_body {
+    bool required = false;
+    std::vector<body_schema> body_schemas;
+};
+
+
+// --------------------------------------------------------------------------
 struct route_info {
     std::string description;
     std::vector<route_parameter> route_parameters;
+    std::vector<std::string> tags;
+    request_body body;
 };
 
 // --------------------------------------------------------------------------

--- a/src/route.cpp
+++ b/src/route.cpp
@@ -62,6 +62,8 @@ route::update_route_info(const beauty::route_info& route_info)
 {
     _route_info.description = route_info.description;
 
+    _route_info.body = route_info.body;
+    _route_info.tags = route_info.tags;
     for (const auto& param: route_info.route_parameters) {
         if (auto found = std::find_if(begin(_route_info.route_parameters),
                     end(_route_info.route_parameters),

--- a/src/server.cpp
+++ b/src/server.cpp
@@ -249,6 +249,27 @@ server::enable_swagger(const char* swagger_entrypoint)
                     description["parameters"] = std::move(parameters);
                 }
 
+                if (!route.route_info().tags.empty()) {
+                    boost::json::array tags;
+                    for (const auto& tag: route.route_info().tags) {
+                        tags.push_back(boost::json::string(tag));
+                    }
+
+                    description["tags"] = tags; 
+                }
+
+                if (!route.route_info().body.body_schemas.empty()) {
+                    boost::json::object schemas;
+                    for (const auto& schema : route.route_info().body.body_schemas) {
+                        schemas[schema.schema_name] = boost::json::object{
+                            { "schema", schema.schema }
+                        };
+                    }
+                    description["requestBody"] = boost::json::object{
+                        {"required", route.route_info().body.required },
+                        {"content", std::move(schemas) }
+                    };
+                }                
                 paths[swagger_path(route)].emplace_object()[to_lower(std::string(to_string(verb)))] = std::move(description);
             }
         }


### PR DESCRIPTION
Hello!

We are using your library in our projects and we were missing some features. 

Mainly, I've noticed that openapi format documentation for swagger does not handle the generation of the format for the request body is not valid. 

I've updated the `route_info` and some related classes to support the request body information.

Then, I've updated the way the openapi is generated so it follows the documentation of the openapi 3.0.

There are many ways how the user could configure the openapi, so I've decided to store the underlying schemas as `boost::json::object` so it is as generic as possible for the user. 

This enables body support for the swagger UI, with these changes we are able to see the body and submit the data to the request body.

Then, another minor change is a support of tags. With tags, we are able to group the endpoints in the swagger by tags. 


Could you please review my changes. 

Have a great one! Thanks in advance.  